### PR TITLE
Enable testing on windows

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,8 +1,11 @@
-cmake -G "NMake Makefiles" -D BUILD_TESTS=OFF -D CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% %SRC_DIR%
+cmake -G "NMake Makefiles" -D CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% %SRC_DIR%
 if errorlevel 1 exit 1
 
 nmake
 if errorlevel 1 exit 1
 
 nmake install
+if errorlevel 1 exit 1
+
+nmake xtest
 if errorlevel 1 exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,12 +12,13 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:
     - toolchain
     - cmake
+    - gtest
 
 test:
   commands:


### PR DESCRIPTION
- We cannot enable on linux because xtensor requires gcc 4.9 or greater (C++ 14 support).
- Adding gtest as a build dependency.